### PR TITLE
Fix duplicated optimizer option extraction

### DIFF
--- a/micrograd_c/engine.py
+++ b/micrograd_c/engine.py
@@ -422,10 +422,6 @@ class Engine:
         # Extract our custom parameters before creating optimizer
         memory_efficient = optimizer_kwargs.pop('memory_efficient', False)
         mini_batch_size = optimizer_kwargs.pop('mini_batch_size', 10)
-            
-        # Extract our custom parameters before creating optimizer
-        memory_efficient = optimizer_kwargs.pop('memory_efficient', False)
-        mini_batch_size = optimizer_kwargs.pop('mini_batch_size', 10)
           # Create optimizer based on type
         if optimizer_type.lower() == 'adam':
             optimizer = Adam(model.parameters, lr=learning_rate, **optimizer_kwargs)


### PR DESCRIPTION
## Summary
- remove duplicate pop calls for `memory_efficient` and `mini_batch_size` in `Engine.train`

## Testing
- `python -m py_compile micrograd_c/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683f53f7a380832aa712dd099144fc1b