### PR TITLE
Fix docstring and example; add simple Huber test

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ print(f"Final loss: {history['train_loss'][-1]:.6f}")
 
 ### Value Class
 
-As in Karpathy's micrograd, the names, classes and methods are mostly the left the same. The `Value` class is a scalar value with automatic differentiation capabilities.
+As in Karpathy's micrograd, the names, classes and methods are mostly left the same. The `Value` class is a scalar value with automatic differentiation capabilities.
 
 #### Key Methods:
 - `Value(data)`: Create a regular value

--- a/examples/basic_net.py
+++ b/examples/basic_net.py
@@ -316,7 +316,8 @@ def demo_advanced_features():
                 target = Value(float(target))
             
             error = pred - target
-            abs_error = error.abs() if hasattr(error, 'abs') else (error * error).sqrt()
+            # Compute absolute error using available operations
+            abs_error = (error * error).pow_safe(0.5)
             
             # Huber loss: quadratic for small errors, linear for large errors
             if abs_error.data <= delta:

--- a/micrograd_c/engine.py
+++ b/micrograd_c/engine.py
@@ -409,8 +409,8 @@ class Engine:
             learning_rate: Learning rate for optimization
             batch_size: Batch size (if None, use full batch)
             loss_fn: Loss function (default: MSE)
-            validation_data: Optional (val_inputs, val_targets) tuple            verbose: Whether to print training progress
-            
+            validation_data: Optional (val_inputs, val_targets) tuple
+            verbose: Whether to print training progress
         Returns:
             Dictionary with training history
         """

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -1,0 +1,43 @@
+import subprocess
+import os
+import shutil
+import sys
+
+# Determine repo root
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRC_DIR = os.path.join(ROOT, 'src')
+LIB_DIR = os.path.join(ROOT, 'micrograd_c', 'lib')
+
+# Build C libraries
+subprocess.run(['make', 'all'], cwd=SRC_DIR, check=True)
+
+# Copy compiled libraries
+for lib in ['value.dll', 'mlp.dll']:
+    shutil.copy(os.path.join(SRC_DIR, lib), os.path.join(LIB_DIR, lib))
+
+sys.path.insert(0, ROOT)
+from micrograd_c import Value, MLP, Engine
+
+def huber_loss(predictions, targets):
+    """Simple Huber loss to verify operations"""
+    total = Value(0.0)
+    delta = 1.0
+    for pred, target in zip(predictions, targets):
+        if not isinstance(target, Value):
+            target = Value(float(target))
+        error = pred - target
+        abs_error = (error * error).pow_safe(0.5)
+        if abs_error.data <= delta:
+            loss = error * error * 0.5
+        else:
+            loss = Value(delta) * (abs_error - Value(delta * 0.5))
+        total = total + loss
+    return total * (1.0 / len(predictions))
+
+model = MLP(1, [2, 1])
+inputs = [[1.0], [2.0]]
+targets = [1.0, 2.0]
+
+history = Engine.train(model, inputs, targets, epochs=1, learning_rate=0.01,
+                       batch_size=2, loss_fn=huber_loss, verbose=False)
+print('Test completed, final loss:', history['train_loss'][-1])


### PR DESCRIPTION
## Summary
- fix a grammar mistake in README
- align `verbose` parameter in Engine docstring
- fix Huber loss example using available Value ops
- add a simple test that builds the C library and trains a tiny network using Huber loss

## Testing
- `python tests/basic_test.py`

------
https://chatgpt.com/codex/tasks/task_e_683f53f79a60832aba393dd73b5d5c0d