### PR TITLE
Add README docs for wave packet example

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,22 @@ model = MLP(nin=3, layer_specs=layers)
 - `'random'`: Random uniform initialization [-1, 1]
 - `'zero'`: Zero initialization
 
+### Wave Packet Layers
+
+`WavePacketLayer` and `WavePacketMLP` provide Gaussian wave packet feature
+extraction for signal-like data. Each packet produces a sine and cosine component
+modulated by a Gaussian envelope. The outputs feed into a regular MLP.
+
+```python
+from micrograd_c import WavePacketMLP, Adam, Value
+
+model = WavePacketMLP(wave_packets=3, mlp_layers=[6, 1], seed=42)
+optimizer = Adam(model.parameters, lr=0.001)
+# forward: prediction = model.forward([Value(x)])
+```
+
+See `examples/nilm_wave_packet.py` for a full training script.
+
 ### Engine Class
 
 The `Engine` class provides training utilities and loss functions.
@@ -474,6 +490,19 @@ loaded_model = MLP.load_parameters('trained_model.json')
 print("Model saved and loaded successfully!")
 ```
 
+### NILM Wave Packet Example
+
+The repository includes a small example that trains a `WavePacketMLP`
+on synthetic non-intrusive load monitoring (NILM) data. Run the
+following commands to train and then perform inference:
+
+```bash
+python examples/nilm_wave_packet.py
+python examples/nilm_inference.py
+```
+
+This saves parameters that can be placed into
+`examples/esp32_inference.c` for deployment on an ESP32.
 
 ## C Implementation Details
 

--- a/examples/esp32_inference.c
+++ b/examples/esp32_inference.c
@@ -1,0 +1,58 @@
+// Simple inference example for ESP32
+#include <math.h>
+#include <stdio.h>
+
+#define WAVE_PACKETS 3
+#define FEATURE_DIM (WAVE_PACKETS*2)
+
+// Replace values below with those generated after training
+static const float A[WAVE_PACKETS] = {0};
+static const float SIGMA_RAW[WAVE_PACKETS] = {0};
+static const float K[WAVE_PACKETS] = {0};
+static const float OMEGA[WAVE_PACKETS] = {0};
+static const float X_P[WAVE_PACKETS] = {0};
+
+// MLP parameters (49 values for architecture [6,1])
+static const float MLP_PARAMS[49] = {0};
+
+static void wave_packet_features(float x, float out[FEATURE_DIM]) {
+    for(int i=0;i<WAVE_PACKETS;i++) {
+        float sigma = expf(SIGMA_RAW[i]);
+        float diff = x - X_P[i];
+        float exponent = (diff*diff)/(2*sigma*sigma);
+        float envelope = expf(-exponent);
+        float phase = K[i]*x - OMEGA[i]*X_P[i];
+        float cosv = cosf(phase);
+        float sinv = sinf(phase);
+        float base = A[i]*envelope;
+        out[2*i] = base*cosv;
+        out[2*i+1] = base*sinv;
+    }
+}
+
+static float relu(float x){return x>0?x:0;}
+
+static float mlp_forward(const float params[49], const float in[FEATURE_DIM]) {
+    // layer1 (6 neurons)
+    float h[6];
+    int idx = 0;
+    for(int n=0;n<6;n++) {
+        float sum = params[idx + 6]; // bias
+        for(int j=0;j<6;j++) sum += params[idx + j]*in[j];
+        h[n] = relu(sum);
+        idx += 7; // 6 weights +1 bias
+    }
+    // layer2 (1 neuron)
+    float out = params[idx + 6];
+    for(int j=0;j<6;j++) out += params[idx + j]*h[j];
+    return out;
+}
+
+int main(void){
+    float sample = 0.25f; // example input
+    float feats[FEATURE_DIM];
+    wave_packet_features(sample, feats);
+    float y = mlp_forward(MLP_PARAMS, feats);
+    printf("prediction: %f\n", y);
+    return 0;
+}

--- a/examples/nilm_inference.py
+++ b/examples/nilm_inference.py
@@ -1,0 +1,32 @@
+"""Run inference using a saved NILM WavePacketMLP model."""
+import json
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from micrograd_c import Value, WavePacketMLP
+
+MODEL_PATH = "nilm_wavepacket_model.json"
+
+# Model architecture must match training
+WAVE_PACKETS = 3
+MLP_LAYERS = [6, 1]
+
+
+def load_model(path: str) -> WavePacketMLP:
+    model = WavePacketMLP(WAVE_PACKETS, MLP_LAYERS)
+    with open(path, "r") as f:
+        data = json.load(f)
+    for p, val in zip(model.parameters, data["params"]):
+        p.data = val
+    return model
+
+
+def predict(model: WavePacketMLP, x: float) -> float:
+    return model.forward([Value(x)])[0].data
+
+
+if __name__ == "__main__":
+    model = load_model(MODEL_PATH)
+    sample = 0.25
+    output = predict(model, sample)
+    print(f"Input {sample:.3f} -> prediction {output:.4f}")

--- a/examples/nilm_wave_packet.py
+++ b/examples/nilm_wave_packet.py
@@ -1,0 +1,53 @@
+"""Example training script for NILM using WavePacketMLP."""
+import random
+import json
+import math
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from micrograd_c import Value, Engine, Adam, WavePacketMLP
+
+# Synthetic dataset generator (placeholder for real NILM data)
+def generate_data(n_samples=200, seed=0):
+    random.seed(seed)
+    data = []
+    for _ in range(n_samples):
+        x = random.uniform(-1.0, 1.0)
+        # simple pattern: combination of low freq and high freq signals
+        y = 0.6 * (x**2) + 0.4 * math.sin(3 * x)
+        data.append(([x], [y]))
+    return data
+
+
+def train_model():
+    train = generate_data(400, seed=1)
+    val = generate_data(80, seed=2)
+    train_inputs = [x for x, y in train]
+    train_targets = [y for x, y in train]
+    val_inputs = [x for x, y in val]
+    val_targets = [y for x, y in val]
+
+    model = WavePacketMLP(wave_packets=3, mlp_layers=[6, 1], seed=42)
+    optimizer = Adam(model.parameters, lr=0.001)
+
+    for epoch in range(60):
+        preds = [model.forward([Value(v[0])]) for v in train_inputs]
+        loss = Engine.mse_loss([p[0] for p in preds], [Value(t[0]) for t in train_targets])
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+        if epoch % 10 == 0:
+            val_preds = [model.forward([Value(v[0])]) for v in val_inputs]
+            val_loss = Engine.mse_loss([p[0] for p in val_preds], [Value(t[0]) for t in val_targets])
+            print(f"Epoch {epoch}: train loss {loss.data:.6f}, val loss {val_loss.data:.6f}")
+
+    model_path = "nilm_wavepacket_model.json"
+    # save parameters
+    params = [p.data for p in model.parameters]
+    with open(model_path, "w") as f:
+        json.dump({"params": params}, f)
+    print("Model saved to", model_path)
+    return model_path
+
+if __name__ == "__main__":
+    train_model()

--- a/micrograd_c/__init__.py
+++ b/micrograd_c/__init__.py
@@ -1,6 +1,7 @@
 from .value import Value
 from .mlp import MLP, Layer
 from .engine import Engine, SGD, Adam, LangevinLandauOptimizer
+from .wavepacket import WavePacketLayer, WavePacketMLP
 
 __version__ = "0.0.1"
 __author__ = "Mehmet Batuhan Duman"
@@ -33,4 +34,14 @@ _initialize_constants()
 import atexit
 atexit.register(_cleanup_constants)
 
-__all__ = ["Value", "MLP", "Layer", "Engine", "SGD", "Adam", "LangevinLandauOptimizer"]
+__all__ = [
+    "Value",
+    "MLP",
+    "Layer",
+    "Engine",
+    "SGD",
+    "Adam",
+    "LangevinLandauOptimizer",
+    "WavePacketLayer",
+    "WavePacketMLP",
+]

--- a/micrograd_c/wavepacket.py
+++ b/micrograd_c/wavepacket.py
@@ -1,0 +1,92 @@
+"""Wave packet based feature extraction layers."""
+
+from typing import List
+import random
+from .value import Value
+from .mlp import MLP
+
+class WavePacketLayer:
+    """Gaussian wave packet feature extractor."""
+    def __init__(self, num_packets: int, input_dim: int = 1, seed: int = None):
+        if seed is not None:
+            random.seed(seed)
+        self.num_packets = num_packets
+        self.input_dim = input_dim
+        self.A = [Value.persistent(random.uniform(-1.0, 1.0)) for _ in range(num_packets)]
+        self.raw_sigma = [Value.persistent(random.uniform(-1.0, 1.0)) for _ in range(num_packets)]
+        self.k = [Value.persistent(random.uniform(-2.0, 2.0)) for _ in range(num_packets)]
+        self.omega = [Value.persistent(random.uniform(-2.0, 2.0)) for _ in range(num_packets)]
+        self.x_p = [Value.persistent(random.uniform(-2.0, 2.0)) for _ in range(num_packets)]
+        self.parameters = self.A + self.raw_sigma + self.k + self.omega + self.x_p
+
+    def forward(self, inputs: List[Value]) -> List[Value]:
+        if len(inputs) != self.input_dim:
+            raise ValueError(f"expected {self.input_dim} inputs")
+        x = inputs[0]
+        outputs = []
+        for i in range(self.num_packets):
+            A = self.A[i]
+            sigma = self.raw_sigma[i].exp()
+            k = self.k[i]
+            omega = self.omega[i]
+            x_p = self.x_p[i]
+            diff = x - x_p
+            exponent = (diff * diff) / (sigma * sigma * Value(2.0))
+            envelope = (Value(0.0) - exponent).exp()
+            phase = k * x - omega * x_p
+            cos_v = self._cos_approx(phase)
+            sin_v = self._sin_approx(phase)
+            base = A * envelope
+            real = base * cos_v
+            imag = base * sin_v
+            outputs.extend([real, imag])
+        return outputs
+
+    def _cos_approx(self, x: Value, terms: int = 4) -> Value:
+        result = Value(1.0)
+        x2 = x * x
+        power = Value(1.0)
+        factorial = 1.0
+        for n in range(1, terms + 1):
+            power = power * x2
+            factorial *= (2*n-1)*(2*n)
+            term = power / Value(factorial)
+            result = result - term if n % 2 == 1 else result + term
+        return result
+
+    def _sin_approx(self, x: Value, terms: int = 4) -> Value:
+        result = x
+        x2 = x * x
+        power = x
+        factorial = 1.0
+        for n in range(1, terms + 1):
+            power = power * x2
+            factorial *= (2*n)*(2*n+1)
+            term = power / Value(factorial)
+            result = result - term if n % 2 == 1 else result + term
+        return result
+
+    def zero_grad(self):
+        for p in self.parameters:
+            p.grad = 0.0
+
+class WavePacketMLP:
+    """MLP preceded by a wave packet layer."""
+    def __init__(self, wave_packets: int, mlp_layers: List[int], seed: int = None):
+        self.wave = WavePacketLayer(wave_packets, input_dim=1, seed=seed)
+        mlp_in = 2 * wave_packets
+        self.mlp = MLP(nin=mlp_in, layer_specs=mlp_layers)
+        if seed is not None:
+            self.mlp.initialize_parameters(method='xavier', seed=seed)
+        self.parameters = self.wave.parameters + self.mlp.parameters
+
+    def forward(self, inputs: List[Value]) -> List[Value]:
+        feats = self.wave.forward(inputs)
+        return self.mlp.forward(feats)
+
+    def zero_grad(self):
+        self.wave.zero_grad()
+        self.mlp.zero_grad()
+
+    def parameter_count(self) -> int:
+        return len(self.parameters)


### PR DESCRIPTION
## Summary
- document new WavePacket layer and example usage in README
- add NILM example section
- minor cleanup of inference script
- add module docstring in WavePacket implementation

## Testing
- `make all`
- `pytest -q`
- `python examples/nilm_wave_packet.py`
- `python examples/nilm_inference.py`


------
https://chatgpt.com/codex/tasks/task_e_683f5d41168c832ab44116953b2226fe